### PR TITLE
Mettre a jour version de hbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM gelog/java:openjdk7
 MAINTAINER Julien Beliveau
 
 # Setting HBASE environment variables
-ENV HBASE_VERSION 1.1.1
+ENV HBASE_VERSION 1.1.2
 ENV HBASE_HOME /usr/local/hbase
 ENV PATH $PATH:$HBASE_HOME/bin
 


### PR DESCRIPTION
La version 1.1.1 de Hbase n'est plus dispnible
La version courante est 1.1.2
